### PR TITLE
Fix Ubuntu 20.04 deprecation

### DIFF
--- a/.github/workflows/semgep.yml
+++ b/.github/workflows/semgep.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:


### PR DESCRIPTION
## Summary
- use `ubuntu-latest` in semgrep workflow

## Testing
- `npm --prefix backend run lint` *(fails: ESLint couldn't find configuration)*
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8da6c48832399d5efe1d884efe4