### PR TITLE
Fix missing config for sequelize migrations

### DIFF
--- a/backend/config/sequelizeConfig.js
+++ b/backend/config/sequelizeConfig.js
@@ -1,0 +1,25 @@
+const config = require('./config');
+
+module.exports = {
+  development: {
+    username: config.db_user,
+    password: config.db_password,
+    database: config.db_name,
+    host: config.db_host,
+    dialect: config.db_dialect,
+  },
+  test: {
+    username: config.db_user,
+    password: config.db_password,
+    database: config.db_name,
+    host: config.db_host,
+    dialect: config.db_dialect,
+  },
+  production: {
+    username: config.db_user,
+    password: config.db_password,
+    database: config.db_name,
+    host: config.db_host,
+    dialect: config.db_dialect,
+  },
+};


### PR DESCRIPTION
## Summary
- add `backend/config/sequelizeConfig.js` so migrations can run

## Testing
- `npm run lint`
- `black --check ./deployment/init-db/init-regions-table.py ./deployment/validate-db/validate-db.py`


------
https://chatgpt.com/codex/tasks/task_e_6840b5641910832394b14612939139c8