### PR TITLE
Remove JSON bodies from 204 responses

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -134,7 +134,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Region'
         '204':
-          description: Region has no subregions
+          description: Region has no subregions. No content is returned.
         '400':
           description: Bad request
         '404':
@@ -218,7 +218,7 @@ paths:
                   geometry:
                     $ref: '#/components/schemas/MultiPolygonGeometry'
         '204':
-          description: Region has no geometry
+          description: Region has no geometry. No content is returned.
         '400':
           description: Bad request
         '404':
@@ -278,7 +278,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/SearchResult'
         '204':
-          description: No regions match the query
+          description: No regions match the query. No content is returned.
         '400':
           description: Bad request
 

--- a/backend/src/controllers/regionController.js
+++ b/backend/src/controllers/regionController.js
@@ -118,7 +118,7 @@ exports.searchRegions = async (req, res) => {
     }));
 
     if (result.length === 0) {
-      return res.status(204).json({ message: 'No regions found' });
+      return res.sendStatus(204);
     }
 
     return res.status(200).json(result);
@@ -185,7 +185,7 @@ async function getSubregions(regionId, hierarchyId, getAll) {
     }
 
     if (subregions.length === 0) {
-      return { data: [], message: 'Region has no subregions', status: 204 };
+      return { data: [], status: 204 };
     }
 
     return { data: subregions, status: 200 };
@@ -301,11 +301,11 @@ exports.getGeometry = async (req, res) => {
   geometries = geometries.filter((g) => g != null);
 
   if (geometries.length === 0) {
-    return res.status(204).json({ message: 'No geometries found' });
+    return res.sendStatus(204);
   }
 
   if (!allHasGeometry) {
-    return res.status(204).json({ message: 'Not all geometries are available' });
+    return res.sendStatus(204);
   }
 
   // Combine all geometries into a single MultiPolygon
@@ -401,6 +401,9 @@ exports.getSubregions = async (req, res) => {
   const hierarchyId = req.query.hierarchyId || 1;
 
   const subregions = await getSubregions(regionId, hierarchyId, getAll);
+  if (subregions.status === 204) {
+    return res.sendStatus(204);
+  }
   const result = subregions.data ? subregions.data.map(
     (r) => r.toApiFormat(),
   ) : { message: subregions.message };


### PR DESCRIPTION
## Summary
- send empty 204 responses in region controller
- document that 204 responses have no content

## Testing
- `npm run lint` (fails: ESLint couldn't find config)
- `npm test` in backend (fails: no test specified)
- `npm run lint` in frontend (fails: ESLint couldn't find config)
- `npm test` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_6840b4d25ad48323884b5483cb1e1a8c